### PR TITLE
entity name and description override

### DIFF
--- a/Content.Shared/_Emberfall/EntityDataOverride/EntityDataOverridePrototype.cs
+++ b/Content.Shared/_Emberfall/EntityDataOverride/EntityDataOverridePrototype.cs
@@ -1,0 +1,27 @@
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Emberfall.EntityDataOverride;
+
+/// <summary>
+///     Prototype for overriding entity name and description without modifying the original entity prototype.
+/// </summary>
+[Prototype]
+public sealed class EntityDataOverridePrototype : IPrototype
+{
+    /// <inheritdoc/>
+    /// <remarks>Must match the entity ID you're trying to override</remarks>
+    [IdDataField]
+    public string ID { get; } = default!;
+
+    /// <summary>
+    ///     The custom name to override the entity's default name.
+    /// </summary>
+    [DataField]
+    public string? Name { get; }
+
+    /// <summary>
+    ///     The custom description to override the entity's default description.
+    /// </summary>
+    [DataField]
+    public string? Description { get; }
+}

--- a/Content.Shared/_Emberfall/EntityDataOverride/EntityDataOverrideSystem.cs
+++ b/Content.Shared/_Emberfall/EntityDataOverride/EntityDataOverrideSystem.cs
@@ -1,0 +1,87 @@
+using JetBrains.Annotations;
+using Robust.Shared.Prototypes;
+
+namespace Content.Shared._Emberfall.EntityDataOverride;
+
+/// <summary>
+///     Handles applying name and description overrides from EntityDataOverridePrototypes.
+/// </summary>
+public sealed class EntityDataOverrideSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+    [Dependency] private readonly MetaDataSystem _metaData = default!;
+
+    private EntityQuery<MetaDataComponent> _metaQuery;
+    private readonly Dictionary<string, EntityDataOverridePrototype> _overrideCache = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _metaQuery = GetEntityQuery<MetaDataComponent>();
+        SubscribeLocalEvent<MetaDataComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<MetaDataComponent, ComponentStartup>(OnStartup);
+
+        // Cache our overrides for faster lookup
+        _prototype.PrototypesReloaded += OnPrototypesReloaded;
+        CacheOverrides();
+    }
+
+    private void OnStartup(Entity<MetaDataComponent> ent, ref ComponentStartup args)
+    {
+        // Apply override for newly spawned entities
+        TryApplyOverride(ent);
+    }
+
+    private void OnMapInit(Entity<MetaDataComponent> ent, ref MapInitEvent ev)
+    {
+        // Apply overrides for map-spawned entities
+        TryApplyOverride(ent);
+    }
+
+    private void OnPrototypesReloaded(PrototypesReloadedEventArgs obj)
+    {
+        if (!obj.ByType.ContainsKey(typeof(EntityDataOverridePrototype)))
+            return;
+
+        // Recache and reapply overrides
+        _overrideCache.Clear();
+        CacheOverrides();
+
+        var query = AllEntityQuery<MetaDataComponent>();
+        while (query.MoveNext(out var uid, out var meta))
+        {
+            TryApplyOverride((uid, meta));
+        }
+    }
+
+    private void CacheOverrides()
+    {
+        foreach (var proto in _prototype.EnumeratePrototypes<EntityDataOverridePrototype>())
+        {
+            _overrideCache[proto.ID] = proto;
+        }
+    }
+
+    /// <summary>
+    ///     Attempts to apply an entity data override to the given entity if one exists.
+    /// </summary>
+    [PublicAPI]
+    public void TryApplyOverride(Entity<MetaDataComponent> ent)
+    {
+        var meta = ent.Comp;
+        if (meta.EntityPrototype == null)
+            return;
+
+        // Check if we have an override for this entity's prototype
+        if (!_overrideCache.TryGetValue(meta.EntityPrototype.ID, out var override_)) // funny
+            return;
+
+        // Only apply non-null overrides
+        if (override_.Name != null)
+            _metaData.SetEntityName(ent, override_.Name, meta);
+
+        if (override_.Description != null)
+            _metaData.SetEntityDescription(ent, override_.Description, meta);
+    }
+}


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
future support for changing the names and descriptions to items while minimizing my suffering (conflicts)
only drawback to this approach is the lack of support for spawn menu as you get these directly from the entity prototype (curse you robusttoolbox)

example usage:
```yml
- type: entityDataOverride
  id: BookSpaceEncyclopedia # Must match the entity prototype ID
  name: ancient space encyclopedia
  description: A weathered encyclopedia containing the collected knowledge of countless star-faring civilizations.
```

![image](https://github.com/user-attachments/assets/3cdf7844-5038-4d11-9d38-d00babbfe5e6)

