### PR TITLE
move the inventory UI above the hotbar

### DIFF
--- a/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml.cs
+++ b/Content.Client/UserInterface/Screens/DefaultGameScreen.xaml.cs
@@ -18,7 +18,7 @@ public sealed partial class DefaultGameScreen : InGameScreen
         SetAnchorPreset(ViewportContainer, LayoutPreset.Wide);
         SetAnchorAndMarginPreset(TopLeft, LayoutPreset.TopLeft, margin: 10);
         SetAnchorAndMarginPreset(Ghost, LayoutPreset.BottomWide, margin: 80);
-        SetAnchorAndMarginPreset(Inventory, LayoutPreset.BottomLeft, margin: 5);
+        SetAnchorAndMarginPreset(Inventory, LayoutPreset.BottomWide, margin: 75); // Emberfall
         SetAnchorAndMarginPreset(Hotbar, LayoutPreset.BottomWide, margin: 5);
         SetAnchorAndMarginPreset(Chat, LayoutPreset.TopRight, margin: 10);
         SetAnchorAndMarginPreset(Alerts, LayoutPreset.TopRight, margin: 10);

--- a/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml.cs
+++ b/Content.Client/UserInterface/Screens/SeparatedChatGameScreen.xaml.cs
@@ -18,7 +18,7 @@ public sealed partial class SeparatedChatGameScreen : InGameScreen
         SetAnchorPreset(ScreenContainer, LayoutPreset.Wide);
         SetAnchorPreset(ViewportContainer, LayoutPreset.Wide);
         SetAnchorPreset(MainViewport, LayoutPreset.Wide);
-        SetAnchorAndMarginPreset(Inventory, LayoutPreset.BottomLeft, margin: 5);
+        SetAnchorAndMarginPreset(Inventory, LayoutPreset.BottomWide, margin: 75); // Emberfall
         SetAnchorAndMarginPreset(TopLeftContainer, LayoutPreset.TopLeft, margin: 10);
         SetAnchorAndMarginPreset(Ghost, LayoutPreset.BottomWide, margin: 80);
         SetAnchorAndMarginPreset(Hotbar, LayoutPreset.BottomWide, margin: 5);

--- a/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
+++ b/Content.Client/UserInterface/Systems/Inventory/InventoryUIController.cs
@@ -43,25 +43,26 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
     private StrippingWindow? _strippingWindow;
     private ItemSlotButtonContainer? _inventoryHotbar;
     private SlotButton? _inventoryButton;
+    private MenuButton? InventoryButton => UIManager.GetActiveUIWidgetOrNull<MenuBar.Widgets.GameTopMenuBar>()?.InventoryButton; // Emberfall
 
     private SlotControl? _lastHovered;
 
-    public override void Initialize()
-    {
-        base.Initialize();
+    // public override void Initialize()
+    // {
+    //     base.Initialize();
+    //
+    //     var gameplayStateLoad = UIManager.GetUIController<GameplayStateLoadController>();
+    //     gameplayStateLoad.OnScreenLoad += OnScreenLoad;
+    // }
 
-        var gameplayStateLoad = UIManager.GetUIController<GameplayStateLoadController>();
-        gameplayStateLoad.OnScreenLoad += OnScreenLoad;
-    }
-
-    private void OnScreenLoad()
-    {
-        if (UIManager.ActiveScreen == null)
-            return;
-
-        if (UIManager.GetActiveUIWidgetOrNull<InventoryGui>() is { } inventoryGui)
-            RegisterInventoryButton(inventoryGui.InventoryButton);
-    }
+    // private void OnScreenLoad()
+    // {
+    //     if (UIManager.ActiveScreen == null)
+    //         return;
+    //
+    //     if (UIManager.GetActiveUIWidgetOrNull<InventoryGui>() is { } inventoryGui)
+    //         RegisterInventoryButton(inventoryGui.InventoryButton);
+    // }
 
     public void OnStateEntered(GameplayState state)
     {
@@ -74,6 +75,29 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
             .Bind(ContentKeyFunctions.OpenInventoryMenu, InputCmdHandler.FromDelegate(_ => ToggleInventoryBar()))
             .Register<ClientInventorySystem>();
     }
+
+    // Begin Emberfall changes
+    public void UnloadButton()
+    {
+        if (InventoryButton == null)
+            return;
+
+        InventoryButton.OnPressed -= ActionButtonPressed;
+    }
+
+    public void LoadButton()
+    {
+        if (InventoryButton == null)
+            return;
+
+        InventoryButton.OnPressed += ActionButtonPressed;
+    }
+
+    private void ActionButtonPressed(BaseButton.ButtonEventArgs args)
+    {
+        ToggleInventoryBar();
+    }
+    // End Emberfall
 
     public void OnStateExited(GameplayState state)
     {
@@ -171,35 +195,20 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
                 _inventoryHotbar.RemoveChild(child);
         }
 
-        var maxWidth = clothing.Max(p => p.Value.ButtonOffset.X) + 1;
-        var maxIndex = clothing.Select(p => GetIndex(p.Value.ButtonOffset)).Max();
-
-        _inventoryHotbar.MaxColumns = maxWidth;
-        _inventoryHotbar.Columns = maxWidth;
-
-        for (var i = 0; i <= maxIndex; i++)
+        foreach (var (key, data) in clothing)
         {
-            var index = i;
-            if (clothing.FirstOrNull(p => GetIndex(p.Value.ButtonOffset) == index) is { } pair)
+            if (!_inventoryHotbar.TryGetButton(key, out var slot))
             {
-                if (_inventoryHotbar.TryGetButton(pair.Key, out var slot))
-                    slot.SetPositionLast();
+                slot = CreateSlotButton(data);
+                _inventoryHotbar.AddButton(slot);
             }
-            else
-            {
-                _inventoryHotbar.AddChild(new Control
-                {
-                    MinSize = new Vector2(64, 64)
-                });
-            }
+
+            var showStorage = _entities.HasComponent<StorageComponent>(data.HeldEntity);
+            var update = new SlotSpriteUpdate(data.HeldEntity, data.SlotGroup, data.SlotName, showStorage);
+            SpriteUpdated(update);
         }
 
-        return;
-
-        int GetIndex(Vector2i position)
-        {
-            return position.Y * maxWidth + position.X;
-        }
+        _inventoryHotbar.Columns = clothing.Count;
     }
 
     private void UpdateStrippingWindow(InventorySlotsComponent? clientInv)
@@ -251,6 +260,7 @@ public sealed class InventoryUIController : UIController, IOnStateEntered<Gamepl
         var shouldBeVisible = !_inventoryHotbar.Visible;
         _inventoryHotbar.Visible = shouldBeVisible;
 
+        InventoryButton?.SetClickPressed(shouldBeVisible); // Emberfall
     }
 
     // Neuron Activation

--- a/Content.Client/UserInterface/Systems/Inventory/Widgets/InventoryGui.xaml
+++ b/Content.Client/UserInterface/Systems/Inventory/Widgets/InventoryGui.xaml
@@ -2,31 +2,20 @@
     xmlns="https://spacestation14.io"
     xmlns:inventory="clr-namespace:Content.Client.UserInterface.Systems.Inventory.Controls"
     xmlns:widgets="clr-namespace:Content.Client.UserInterface.Systems.Inventory.Widgets"
-    xmlns:controls="clr-namespace:Content.Client.UserInterface.Controls"
     Name="InventoryInterface"
     VerticalExpand="True"
     VerticalAlignment="Bottom"
     Orientation="Horizontal"
     HorizontalAlignment="Center">
-    <Control HorizontalAlignment="Center">
-        <!-- Needs to default to invisible because if we attach to a non-slots entity this will never get unset -->
-        <controls:SlotButton
-            Name="InventoryButton"
-            Access="Public"
-            Visible="False"
-            VerticalAlignment="Bottom"
-            HorizontalExpand="False"
-            VerticalExpand="False"
-            ButtonTexturePath="Slots/toggle"/>
-        <inventory:ItemSlotButtonContainer
-            Name="InventoryHotbar"
-            Access="Public"
-            Visible="False"
-            MaxColumns="3"
-            SlotGroup="Default"
-            ExpandBackwards="True"
-            VerticalExpand="True"
-            HorizontalAlignment="Center"
-        />
-    </Control>
+    <inventory:ItemSlotButtonContainer
+        Name="InventoryHotbar"
+        Access="Public"
+        Visible="False"
+        Columns="12"
+        MaxColumns="12"
+        SlotGroup="Default"
+        VerticalExpand="False"
+        HorizontalExpand="True"
+        HorizontalAlignment="Center"
+    />
 </widgets:InventoryGui>

--- a/Content.Client/UserInterface/Systems/MenuBar/GameTopMenuBarUIController.cs
+++ b/Content.Client/UserInterface/Systems/MenuBar/GameTopMenuBarUIController.cs
@@ -7,6 +7,7 @@ using Content.Client.UserInterface.Systems.Emotes;
 using Content.Client.UserInterface.Systems.EscapeMenu;
 using Content.Client.UserInterface.Systems.Gameplay;
 using Content.Client.UserInterface.Systems.Guidebook;
+using Content.Client.UserInterface.Systems.Inventory; // Emberfall
 using Content.Client.UserInterface.Systems.MenuBar.Widgets;
 using Content.Client.UserInterface.Systems.Sandbox;
 using Robust.Client.UserInterface.Controllers;
@@ -24,6 +25,7 @@ public sealed class GameTopMenuBarUIController : UIController
     [Dependency] private readonly SandboxUIController _sandbox = default!;
     [Dependency] private readonly GuidebookUIController _guidebook = default!;
     [Dependency] private readonly EmotesUIController _emotes = default!;
+    [Dependency] private readonly InventoryUIController _inventory = default!; // Emberfall - why isnt this sorted istg
 
     private GameTopMenuBar? GameTopMenuBar => UIManager.GetActiveUIWidgetOrNull<GameTopMenuBar>();
 
@@ -47,6 +49,7 @@ public sealed class GameTopMenuBarUIController : UIController
         _action.UnloadButton();
         _sandbox.UnloadButton();
         _emotes.UnloadButton();
+        _inventory.UnloadButton(); // Emberfall
     }
 
     public void LoadButtons()
@@ -60,5 +63,6 @@ public sealed class GameTopMenuBarUIController : UIController
         _action.LoadButton();
         _sandbox.LoadButton();
         _emotes.LoadButton();
+        _inventory.LoadButton(); // Emberfall
     }
 }

--- a/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
+++ b/Content.Client/UserInterface/Systems/MenuBar/Widgets/GameTopMenuBar.xaml
@@ -43,6 +43,16 @@
         HorizontalExpand="True"
         AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"
         />
+    <!-- Emberfall - Bring back the old UI -->
+    <ui:MenuButton
+        Name="InventoryButton"
+        Access="Internal"
+        Icon="{xe:Tex '/Textures/Interface/inventory.svg.192dpi.png'}"
+        ToolTip="{Loc 'game-hud-open-inventory-menu-button-tooltip'}"
+        BoundKey = "{x:Static is:ContentKeyFunctions.OpenInventoryMenu}"
+        MinSize="42 64"
+        HorizontalExpand="True"
+        AppendStyleClass="{x:Static style:StyleBase.ButtonSquare}"/>
     <ui:MenuButton
         Name="EmotesButton"
         Access="Internal"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

only took 378 days
contains all of the fixes from the original UI, and the inventory is still attached to the game screen instead of the hotbar itself (rather than me fully reverting it), just modified the inventory bar itself, re-added the button and changed the anchor point

never forget what they took away from us
![image](https://github.com/user-attachments/assets/ad113b99-1db1-4905-8459-b0335f917004)
